### PR TITLE
Fix build by invoking gfortran directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,41 @@
 import os, sys
-from setuptools import setup, find_packages
-from setuptools.command.build_py import build_py
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 import subprocess
 
-class Compile(build_py):
-    """Custom build setup to help run needed shell commands
+class GfortranExtension(Extension):
+    def __init__(self, name, sourcedir='', input='', output=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+        self.input = os.path.join(self.sourcedir, input)
+        self.output = os.path.join(self.sourcedir, output)
 
-    Inspired by https://stackoverflow.com/a/27953695/1237531"""
+class GfortranBuild(build_ext):
     def run(self):
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        source_path = os.path.join(dir_path, 'glmnet_python/GLMnet.f')
-        output_path = os.path.join(dir_path, 'glmnet_python/GLMnet.so')
-        compile = subprocess.check_output(['gfortran',
-            source_path,
-            '-fPIC',
-            '-fdefault-real-8',
-            '-shared',
-            '-o',
-            output_path
-        ])
-        build_py.run(self)
+        try:
+            out = subprocess.check_output(['gfortran', '--version'])
+        except OSError:
+            raise RuntimeError("gfortran must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        gfortran_args = ['-fPIC',
+                         '-fdefault-real-8',
+                         '-shared',
+                         '-o',
+                         ext.output]
+
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+
+        env = os.environ.copy()
+        subprocess.check_call(['gfortran', ext.input] + gfortran_args, cwd=self.build_temp, env=env)
 
 setup(name='glmnet_python',
-      version = '0.2.2',
+      version = '1.0.0',
       description = 'Python version of glmnet, from Stanford University',
       long_description=open('README.md').read(),
       url="https://github.com/johnlees/glmnet_python",
@@ -42,5 +55,7 @@ setup(name='glmnet_python',
         'Operating System :: Unix',
         ],
       keywords='glm glmnet ridge lasso elasticnet',
-      cmdclass={'build_py': Compile},
+      ext_modules=[GfortranExtension('GLMnet', 'glmnet_python',
+                                     'GLMnet.f', 'GLMnet.so')],
+      cmdclass={'build_ext': GfortranBuild},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,25 @@
 import os, sys
 from setuptools import setup, find_packages
+from setuptools.command.build_py import build_py
 import subprocess
+
+class Compile(build_py):
+    """Custom build setup to help run needed shell commands
+
+    Inspired by https://stackoverflow.com/a/27953695/1237531"""
+    def run(self):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        source_path = os.path.join(dir_path, 'glmnet_python/GLMnet.f')
+        output_path = os.path.join(dir_path, 'glmnet_python/GLMnet.so')
+        compile = subprocess.check_output(['gfortran',
+            source_path,
+            '-fPIC',
+            '-fdefault-real-8',
+            '-shared',
+            '-o',
+            output_path
+        ])
+        build_py.run(self)
 
 setup(name='glmnet_python',
       version = '0.2.2',
@@ -22,5 +41,6 @@ setup(name='glmnet_python',
         'Programming Language :: Python :: 3.4',
         'Operating System :: Unix',
         ],
-      keywords='glm glmnet ridge lasso elasticnet'
-      )
+      keywords='glm glmnet ridge lasso elasticnet',
+      cmdclass={'build_py': Compile},
+)


### PR DESCRIPTION
Relatively ugly hack to allow downstream packages to use the library

I could not get `f2py` (numpy external modules builder) to work with `glmnet_python`, so I resorted to this hack, which is slightly more elegant than [this other fork](https://github.com/hanfang/glmnet_py/blob/master/setup.py#L5).